### PR TITLE
Fix config not saving

### DIFF
--- a/src/modules/core/config.service.ts
+++ b/src/modules/core/config.service.ts
@@ -106,7 +106,7 @@ export class Config {
   }
   async open() {
     if (!(await this.datastore.has(new Key('config')))) {
-      this.init()
+      await this.init()
       return
     }
     var buf = await this.datastore.get(new Key('config'))


### PR DESCRIPTION
When the program couldn't connect to IPFS due to it not being run locally caused by the following code: https://github.com/spknetwork/video-encoder/blob/8ca1b8111f9614f673f4e082585fbf428d33ca1a/src/modules/core/gatewayClient.service.ts#L265-L275
the generated config wouldn't be saved, and the user couldn't modify it to change their settings. This awaits for the initialization to be finished fixing the issue and letting the config be saved and the user can modify it.